### PR TITLE
Improve net10 native dll probing

### DIFF
--- a/Legacy/Program.cs
+++ b/Legacy/Program.cs
@@ -254,6 +254,11 @@ static class Program
 
     private static void SetupGame(string[] args)
     {
+#if NETCOREAPP
+        if (OperatingSystem.IsWindows())
+            SetupNativeDllSearchPath(ConfigManager.Instance.GameDir);
+#endif
+
         string bin64Dir = ConfigManager.Instance.GameDir;
         string originalLoaderPath = Path.Combine(bin64Dir, OldLauncher);
         Patch_PrepareCrashReport.SpaceEngineersPath = originalLoaderPath;
@@ -301,4 +306,16 @@ static class Program
 
         return new Thread(ProgressPoll) { IsBackground = true, Name = "ProgressPoll" };
     }
+
+#if NETCOREAPP
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetDllDirectory(string lpPathName);
+
+    private static void SetupNativeDllSearchPath(string gameDir)
+    {
+        // Ensure native game dependencies (e.g. Havok.dll) are discoverable under .NET Core/.NET 10
+        if (!string.IsNullOrEmpty(gameDir))
+            SetDllDirectory(gameDir);
+    }
+#endif
 }


### PR DESCRIPTION
### Summary

This PR ensures that native game DLLs are discoverable when launching Space Engineers via `Interim.exe` under .NET 10 and Windows.

### Background

Under .NET (Core/10) on Windows, native DLL resolution does not implicitly probe the game directory. As a result, `Interim.exe` can fail with a `DllNotFoundException` (for example when loading `Havok.dll`) on **some systems**.

On many Windows systems, this issue does not surface because the native DLL search path is implicitly satisfied by the execution environment (e.g. PATH entries, launch context, prior native loads, etc.).

### Fix

Explicitly add the game directory to the native DLL search path before starting Space Engineers when running under `NETCOREAPP`.

This makes native DLL resolution explicit and deterministic across environments, without changing behavior for the legacy launcher.

### Scope

* Affects `Interim.exe` on Windows only
* No changes to `Legacy.exe`
* Minimal, localized change

### Context

This PR is based on the debugging discussion in Discord regarding an `Interim.exe` startup crash caused by missing native DLLs. 

Discussion in Discord: https://discord.com/channels/1378756728107040829/1467840378056081552

Diagnostic evidence is available if needed.
