### PR TITLE
Fix dotnet build for Shared net48 target

### DIFF
--- a/Shared/Shared.csproj
+++ b/Shared/Shared.csproj
@@ -14,6 +14,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <PropertyGroup>
     <Platforms>x64</Platforms>
@@ -50,5 +51,6 @@
     <PackageReference Include="NLog" Version="6.0.3" />
     <PackageReference Include="NuGet.Resolver" Version="6.7.1" />
     <PackageReference Include="protobuf-net" Version="2.4.9" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Enable GenerateResourceUsePreserializedResources and add System.Resources.Extensions package so non-string resx resources (SplashScreen icons/images) compile under the .NET SDK toolchain. No-op for net8/net10 targets where this is already the default.