### PR TITLE
Dev folder improvements

### DIFF
--- a/Legacy/Screens/SourcesMenu.cs
+++ b/Legacy/Screens/SourcesMenu.cs
@@ -561,14 +561,19 @@ internal class SourcesMenu(SourcesConfig sources) : PluginScreen(size: new Vecto
     private void AddDevelopmentFolder(MyGuiControlButton btn)
     {
         MyGuiSoundManager.PlaySound(GuiSounds.MouseClick);
-        Tools.OpenFolderDialog("Open a development folder", PromptDevelopmentFolderFile);
+        Tools.OpenFileDialog(
+            "Open a plugin data file",
+            null,
+            [new FilePickerFilter { Name = "XML files (*.xml)", Patterns = ["*.xml"] }],
+            AddDevelopmentFolder
+        );
     }
 
-    private void PromptDevelopmentFolderFile(string folder)
+    private void AddDevelopmentFolder(string file)
     {
-        DirectoryInfo directory = new(folder);
-        folder = directory.FullName;
-        string id = directory.Name;
+        file = Path.GetFullPath(file);
+        string folder = Path.GetDirectoryName(file);
+        string id = Path.GetFileName(folder);
 
         if (LocalPluginSources.Any(source => source.Name == id))
         {
@@ -582,41 +587,11 @@ internal class SourcesMenu(SourcesConfig sources) : PluginScreen(size: new Vecto
             return;
         }
 
-        MyGuiScreenMessageBox dialog = MyGuiSandbox.CreateMessageBox(
-            styleEnum: MyMessageBoxStyleEnum.Info,
-            buttonType: MyMessageBoxButtonsType.YES_NO,
-            messageCaption: new StringBuilder("Pulsar"),
-            messageText: new StringBuilder("Select a plugin data file?"),
-            callback: result =>
-            {
-                if (result == MyGuiScreenMessageBox.ResultEnum.YES)
-                    OpenDevelopmentFolderFile(folder);
-                else
-                    AddDevelopmentFolder(folder);
-            }
-        );
-        MyGuiSandbox.AddScreen(dialog);
-    }
-
-    private void OpenDevelopmentFolderFile(string folder)
-    {
-        Tools.OpenFileDialog(
-            "Open a plugin data file",
-            folder,
-            [new FilePickerFilter { Name = "XML files (*.xml)", Patterns = ["*.xml"] }],
-            (file) => AddDevelopmentFolder(folder, file)
-        );
-    }
-
-    private void AddDevelopmentFolder(string folder, string file = null)
-    {
-        file = Tools.GetRelativePath(folder, file) ?? file;
-
         LocalPluginConfig plugin = new()
         {
-            Name = Path.GetFileName(folder),
+            Name = id,
             Folder = folder,
-            File = file,
+            File = Path.GetFileName(file),
             Enabled = true,
         };
 

--- a/Legacy/Screens/SourcesMenu.cs
+++ b/Legacy/Screens/SourcesMenu.cs
@@ -570,7 +570,7 @@ internal class SourcesMenu(SourcesConfig sources) : PluginScreen(size: new Vecto
         folder = directory.FullName;
         string id = directory.Name;
 
-        if (LocalPluginSources.Any(source => new DirectoryInfo(source.Folder).Name == id))
+        if (LocalPluginSources.Any(source => source.Name == id))
         {
             MyGuiSandbox.AddScreen(
                 MyGuiSandbox.CreateMessageBox(

--- a/Modern/Screens/SourcesScreen/SourcesScreenViewModel.cs
+++ b/Modern/Screens/SourcesScreen/SourcesScreenViewModel.cs
@@ -268,14 +268,19 @@ internal class SourcesScreenViewModel : ScreenViewModel
 
     public void AddDevFolder()
     {
-        Tools.OpenFolderDialog("Open a development folder", PromptDevFolderFile);
+        Tools.OpenFileDialog(
+            "Open a plugin data file",
+            null,
+            [new FilePickerFilter { Name = "XML files (*.xml)", Patterns = ["*.xml"] }],
+            AddDevFolder
+        );
     }
 
-    private void PromptDevFolderFile(string folder)
+    private void AddDevFolder(string file)
     {
-        DirectoryInfo directory = new(folder);
-        folder = directory.FullName;
-        string id = directory.Name;
+        file = Path.GetFullPath(file);
+        string folder = Path.GetDirectoryName(file);
+        string id = Path.GetFileName(folder);
 
         if (
             PluginSources.Any(source =>
@@ -293,40 +298,11 @@ internal class SourcesScreenViewModel : ScreenViewModel
             return;
         }
 
-        var filePrompt = ScreenTools.GetDefaultYesNoDialog();
-        filePrompt.Title = ScreenTools.GetKeyFromString("Pulsar");
-        filePrompt.Content = ScreenTools.GetKeyFromString("Select a plugin data file?");
-
-        ScreenTools
-            .GetSharedUIComponent()
-            .ShowDialog(
-                new TwoOptionsDialogViewModel(filePrompt)
-                {
-                    ConfirmAction = () => OpenDevFolderFile(folder),
-                    CancelAction = () => AddDevFolder(folder),
-                }
-            );
-    }
-
-    private void OpenDevFolderFile(string folder)
-    {
-        Tools.OpenFileDialog(
-            "Open a plugin data file",
-            folder,
-            [new FilePickerFilter { Name = "XML files (*.xml)", Patterns = ["*.xml"] }],
-            (file) => AddDevFolder(folder, file)
-        );
-    }
-
-    private void AddDevFolder(string folder, string file = null)
-    {
-        file = Tools.GetRelativePath(folder, file) ?? file;
-
         LocalPluginConfig plugin = new()
         {
-            Name = Path.GetFileName(folder),
+            Name = id,
             Folder = folder,
-            File = file,
+            File = Path.GetFileName(file),
             Enabled = true,
         };
 

--- a/Modern/Screens/SourcesScreen/SourcesScreenViewModel.cs
+++ b/Modern/Screens/SourcesScreen/SourcesScreenViewModel.cs
@@ -279,8 +279,7 @@ internal class SourcesScreenViewModel : ScreenViewModel
 
         if (
             PluginSources.Any(source =>
-                source.Config is LocalPluginConfig local
-                && new DirectoryInfo(local.Folder).Name == id
+                source.Config is LocalPluginConfig local && local.Name == id
             )
         )
         {

--- a/Shared/Config/ProfilesConfig.cs
+++ b/Shared/Config/ProfilesConfig.cs
@@ -108,10 +108,10 @@ public class ProfilesConfig(string folderPath)
         }
 
         {
-            Profile current = null;
-            string file = Path.Combine(folderPath, currentKey + ".xml");
+            string profileKey = Tools.CleanFileName(Flags.Profile);
+            string file = Path.Combine(folderPath, profileKey + ".xml");
 
-            if (File.Exists(file))
+            if (!config.profiles.TryGetValue(profileKey, out Profile current) && File.Exists(file))
             {
                 using FileStream fs = File.OpenRead(file);
 
@@ -127,11 +127,11 @@ public class ProfilesConfig(string folderPath)
                 config.Current = current;
             else
             {
-                config.Current = new Profile(currentKey);
+                config.Current = new Profile(Flags.Profile);
 
                 if (File.Exists(file))
                 {
-                    LogFile.Error($"An error occurred while loading the {currentKey} profile");
+                    LogFile.Error($"An error occurred while loading the {profileKey} profile");
                     int backupCount = Directory
                         .EnumerateFiles(folderPath)
                         .Where(file => Path.GetExtension(file).Contains(".bak"))
@@ -143,9 +143,9 @@ public class ProfilesConfig(string folderPath)
 
                     File.Move(file, file + suffix);
 
-                    string path = Path.Combine("Profiles", currentKey + ".xml" + suffix);
+                    string path = Path.Combine("Profiles", profileKey + ".xml" + suffix);
                     string message =
-                        "The current profile could not be loaded!\n"
+                        $"The {profileKey} profile could not be loaded!\n"
                         + "The list of enabled plugins has been reset.\n\n"
                         + $"The original profile has been saved to {path}";
                     Tools.ShowMessageBox(message, PromptButtons.Ok, PromptIcon.Warning);

--- a/Shared/Config/ProfilesConfig.cs
+++ b/Shared/Config/ProfilesConfig.cs
@@ -17,6 +17,15 @@ public class ProfilesConfig(string folderPath)
     public Profile Current { get; set; }
     public IEnumerable<Profile> Profiles => profiles.Values;
 
+    private static bool ReadOnly(string operation)
+    {
+        if (!Flags.ProfileIsSpecified)
+            return false;
+
+        LogFile.WriteLine($"Skipped {operation}: -profile prevents changing profiles on disk");
+        return true;
+    }
+
     public void Save(string key = null)
     {
         Profile profile;
@@ -24,6 +33,9 @@ public class ProfilesConfig(string folderPath)
             profile = Current;
         else
             profile = profiles[key];
+
+        if (ReadOnly($"saving profile {profile.Name}"))
+            return;
 
         try
         {
@@ -57,6 +69,10 @@ public class ProfilesConfig(string folderPath)
     public void Remove(string key)
     {
         profiles.Remove(key);
+
+        if (ReadOnly($"deleting profile {key}"))
+            return;
+
         string path = Path.Combine(folderPath, key + ".xml");
         File.Delete(path);
     }
@@ -66,10 +82,13 @@ public class ProfilesConfig(string folderPath)
         Profile profile = profiles[key];
         profiles.Remove(key);
 
-        File.Delete(Path.Combine(folderPath, key + ".xml"));
-
         profile.Name = newName;
         profiles[profile.Key] = profile;
+
+        if (ReadOnly($"renaming profile {key} to {profile.Key}"))
+            return;
+
+        File.Delete(Path.Combine(folderPath, key + ".xml"));
 
         Save(profile.Key);
     }
@@ -132,6 +151,10 @@ public class ProfilesConfig(string folderPath)
                 if (File.Exists(file))
                 {
                     LogFile.Error($"An error occurred while loading the {profileKey} profile");
+
+                    if (ReadOnly($"backing up broken profile {profileKey}"))
+                        return config;
+
                     int backupCount = Directory
                         .EnumerateFiles(folderPath)
                         .Where(file => Path.GetExtension(file).Contains(".bak"))

--- a/Shared/Data/LocalFolderPlugin.cs
+++ b/Shared/Data/LocalFolderPlugin.cs
@@ -26,9 +26,9 @@ public class LocalFolderPlugin : PluginData
 
     public string Folder;
 
-    public LocalFolderPlugin(string folder)
+    public LocalFolderPlugin(string folder, string name = null)
     {
-        Id = Path.GetFileName(folder.TrimEnd(Path.DirectorySeparatorChar));
+        Id = name ?? Path.GetFileName(folder.TrimEnd(Path.DirectorySeparatorChar));
         Folder = folder;
         Status = PluginStatus.None;
         FriendlyName = Id;

--- a/Shared/Flags.cs
+++ b/Shared/Flags.cs
@@ -92,6 +92,7 @@ public static class Flags
     public static bool LazySteam { get; private set; }
     public static bool MultiInstance { get; private set; }
     public static string Profile { get; private set; }
+    public static bool ProfileIsSpecified { get; private set; }
 
     static Flags()
     {
@@ -126,6 +127,7 @@ public static class Flags
         LazySteam = HasArg(Arguments.LazySteam);
         MultiInstance = HasArg(Arguments.MultiInstance);
         Profile = GetArgValue(Arguments.Profile) ?? "Current";
+        ProfileIsSpecified = GetArgValue(Arguments.Profile) != null;
     }
 
     public static bool HelpRequested => Arguments.HelpAliases.Any(alias => HasArg([alias]));

--- a/Shared/Flags.cs
+++ b/Shared/Flags.cs
@@ -41,6 +41,7 @@ file static class Arguments
     public static readonly string[] NoPrompt = ["no", "prompt"];
     public static readonly string[] LazySteam = ["lazy", "steam"];
     public static readonly string[] MultiInstance = ["multi", "instance"];
+    public static readonly string[] Profile = ["profile"];
 
     public static readonly string[] HelpAliases = ["help", "h", "?"];
 
@@ -90,6 +91,7 @@ public static class Flags
     public static bool NoPrompt { get; private set; }
     public static bool LazySteam { get; private set; }
     public static bool MultiInstance { get; private set; }
+    public static string Profile { get; private set; }
 
     static Flags()
     {
@@ -123,6 +125,7 @@ public static class Flags
         NoPrompt = HasArg(Arguments.NoPrompt);
         LazySteam = HasArg(Arguments.LazySteam);
         MultiInstance = HasArg(Arguments.MultiInstance);
+        Profile = GetArgValue(Arguments.Profile) ?? "Current";
     }
 
     public static bool HelpRequested => Arguments.HelpAliases.Any(alias => HasArg([alias]));
@@ -146,6 +149,7 @@ public static class Flags
 
             Options:
             {options}
+              {"-profile <name>", -18}Load the named profile instead of Current.
 
             Options are case-insensitive. Linux form --no-splash and Windows form
             /NoSplash are also accepted. Help aliases include --help, -h, and /?.
@@ -197,6 +201,8 @@ public static class Flags
             changed.Add("LazySteam");
         if (MultiInstance)
             changed.Add("MultiInstance");
+        if (Profile != "Current")
+            changed.Add($"Profile={Profile}");
 
         if (changed.Count > 0)
             LogFile.WriteLine($"Enabled flags: {string.Join(" ", changed)}");
@@ -215,6 +221,26 @@ public static class Flags
                 || arg.Equals(windows, StringComparison.OrdinalIgnoreCase)
                 || arg.Equals(spaceEngineers, StringComparison.OrdinalIgnoreCase)
             );
+    }
+
+    private static string GetArgValue(string[] words)
+    {
+        string linux = ToLinuxArg(words);
+        string windows = ToWindowsArg(words);
+        string spaceEngineers = ToSpaceEngineersArg(words);
+
+        string[] args = Environment.GetCommandLineArgs();
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (
+                args[i].Equals(linux, StringComparison.OrdinalIgnoreCase)
+                || args[i].Equals(windows, StringComparison.OrdinalIgnoreCase)
+                || args[i].Equals(spaceEngineers, StringComparison.OrdinalIgnoreCase)
+            )
+                return args[i + 1];
+        }
+
+        return null;
     }
 
     private static string ToLinuxArg(string[] words) => $"--{string.Join("-", words)}";

--- a/Shared/PluginList.cs
+++ b/Shared/PluginList.cs
@@ -283,7 +283,7 @@ public class PluginList : IEnumerable<PluginData>
         if (!Directory.Exists(source.Folder))
             return;
 
-        LocalFolderPlugin local = new(source.Folder) { Source = "DevFolder" };
+        LocalFolderPlugin local = new(source.Folder, source.Name) { Source = "DevFolder" };
         local.TryLoadDataFile(source.File);
         LoadPluginData(local);
         localPlugins[local.Id] = local;
@@ -449,7 +449,7 @@ public class PluginList : IEnumerable<PluginData>
             if (source.Enabled)
                 AddLocalPlugin(source);
             else
-                localPlugins.Remove(new DirectoryInfo(source.Folder).Name);
+                localPlugins.Remove(source.Name ?? new DirectoryInfo(source.Folder).Name);
 
         string[] localDlls = [.. EnumerateLocalPlugins()];
         foreach (string dll in localDlls)

--- a/Shared/Tools.cs
+++ b/Shared/Tools.cs
@@ -294,7 +294,7 @@ public static class Tools
 #if NETFRAMEWORK
             : "CLR";
 #else
-            : "CoreCLR";
+            : "NETCoreApp";
 #endif
 
     public static string[] GetCompilationSymbols(bool trusted)


### PR DESCRIPTION
- Simplified the "add development folder" flow in both the legacy and modern Sources screens: the user now picks the plugin's XML data file directly, and the containing folder is derived from it. This removes the folder picker plus the extra "Select a plugin data file?" yes/no dialog step.
- Local plugin sources are now identified by their configured `Name` instead of re-deriving the folder name at every use. `LocalFolderPlugin` accepts an explicit name, `PluginList` passes the source's name when adding or removing a dev folder plugin, and the duplicate check on the Sources screens compares against `Name`.
- Fixed the `DotNetCompat` compilation symbol for .NET (non-Framework) builds, which was emitted as `CoreCLR` instead of the expected `NETCoreApp`.
- Added -profile argument to select the profile to load.