### PR TITLE
Build property overrides

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,12 +1,27 @@
 <Project>
   <!-- Override Project Settings -->
   <PropertyGroup>
-    <TargetPlatform></TargetPlatform>   <!-- Target platform for Pulsar build -->
-    <Pulsar></Pulsar>                   <!-- Folder where Pulsar will be deployed -->
-    <Bin64></Bin64>                     <!-- Folder containing SpaceEngineers.exe -->
-    <Game2></Game2>                     <!-- Folder containing SpaceEngineers2.exe -->
-    <Steamworks></Steamworks>           <!-- Folder containing Linux Steamworks.NET and steam_api -->
+    <!-- Target platform for Pulsar build -->
+    <TargetPlatform></TargetPlatform>
+
+    <!-- Folder where Pulsar will be deployed -->
+    <Pulsar></Pulsar>
+
+    <!-- Folder containing SpaceEngineers.exe -->
+    <Bin64></Bin64>
+
+    <!-- Folder containing SpaceEngineers2.exe -->
+    <Game2></Game2>
+
+    <!-- Folder containing Linux Steamworks.NET and steam_api -->
+    <Steamworks></Steamworks>
   </PropertyGroup>
+
+  <!-- Local developer overrides for the settings above; ignored by Git (*.user).
+       Copy the first PropertyGroup of this file into Directory.Build.props.user
+       and fill in your local paths there. -->
+  <Import Project="$(MSBuildThisFileDirectory)Directory.Build.props.user"
+          Condition="Exists('$(MSBuildThisFileDirectory)Directory.Build.props.user')" />
 
   <!-- Default Project Settings -->
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Starting Space Engineers from Steam will now open Pulsar as well!<br>
 Pulsar officially endorses the [PluginHub](https://github.com/StarCpt/PluginHub) for high-quality vetted plugins.<br>
 Further sources may be added in-game but make sure you fully understand the risks.<br>
 
+## Development
+Local build paths (`TargetPlatform`, `Pulsar`, `Bin64`, `Game2`, `Steamworks`) are empty in `Directory.Build.props`.<br>
+To override them, copy its first `PropertyGroup` into `Directory.Build.props.user` (git-ignored) in the repo root,
+wrapped in a top-level `<Project>` element, and fill in your paths.<br>
+Anything left empty there falls back to the defaults in `Directory.Build.props`.<br>
+
 ## Contact
 We have an active [Discord](https://discord.gg/z8ZczP2YZY) for updates and developer information.<br>
 GitHub contributions and bug reports are also welcomed!<br>


### PR DESCRIPTION
- `Directory.Build.props` now imports an optional `Directory.Build.props.user` from the repo root, letting each developer set local build paths (`TargetPlatform`, `Pulsar`, `Bin64`, `Game2`, `Steamworks`) without touching a tracked file. The import sits between the override block and the defaults, so user values win while anything left empty still falls back to the existing auto-detection.
- `Directory.Build.props.user` is git-ignored via the existing `*.user` rule, which removes the recurring risk of committing machine-specific paths.
- Property comments moved above their elements for readability.
- README gains a short Development section describing how to create and use the override file.