### PR TITLE
Magnetar upstream fixes

### DIFF
--- a/Shared/Arguments/Parser.cs
+++ b/Shared/Arguments/Parser.cs
@@ -65,10 +65,7 @@ public static class Parser
 
     private static string Normalize(string arg)
     {
-        // Only option-style tokens are normalized. Values and other bare
-        // tokens pass through untouched, so an argument value that happens
-        // to match a flag name (e.g. a folder called "debug") is not
-        // rewritten into that flag.
+        // Only normalize option-style tokens
         if (string.IsNullOrEmpty(arg) || (arg[0] != '-' && arg[0] != '/'))
             return arg;
 

--- a/Shared/Arguments/Parser.cs
+++ b/Shared/Arguments/Parser.cs
@@ -65,6 +65,13 @@ public static class Parser
 
     private static string Normalize(string arg)
     {
+        // Only option-style tokens are normalized. Values and other bare
+        // tokens pass through untouched, so an argument value that happens
+        // to match a flag name (e.g. a folder called "debug") is not
+        // rewritten into that flag.
+        if (string.IsNullOrEmpty(arg) || (arg[0] != '-' && arg[0] != '/'))
+            return arg;
+
         string trimmed = arg.Replace("/", "").Replace("-", "");
 
         if (trimmed is "h" or "H" or "?")

--- a/Shared/Interface/InterfaceClient.cs
+++ b/Shared/Interface/InterfaceClient.cs
@@ -45,6 +45,10 @@ public sealed class InterfaceClient(string interfacePath) : IDisposable
             Buttons = buttons,
             Icon = icon,
         };
+
+        if (Flags.Current.NoPrompt)
+            LogFile.Warn($"Prompt cancelled: {message}");
+
         return Send(InterfaceOperation.PromptShow, prompt: request).PromptResult;
     }
 

--- a/Shared/Network/GitHub.cs
+++ b/Shared/Network/GitHub.cs
@@ -11,15 +11,18 @@ public static class GitHub
         Environment.GetEnvironmentVariable("PULSAR_GITHUB_TOKEN");
 
     internal static bool IsTokenHost(Uri uri) =>
-        uri.Host is "api.github.com" or "github.com" or "raw.githubusercontent.com";
+        uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+        && uri.Host.Equals("api.github.com", StringComparison.OrdinalIgnoreCase);
 
     private const string CommitInfo = "https://api.github.com/repos/{0}/commits/{1}";
     private const string ReleaseInfo = "https://api.github.com/repos/{0}/releases";
-    private const string FetchRepo = "https://github.com/{0}/archive/{1}.zip";
-    private const string FetchFile = "https://raw.githubusercontent.com/{0}/{1}/";
+    private const string FetchRepo = "https://api.github.com/repos/{0}/zipball/{1}";
+    private const string FetchFile = "https://api.github.com/repos/{0}/contents/{1}?ref={2}";
+    private const string RawContent = "application/vnd.github.raw+json";
 
     public static Stream GetRepoArchive(string repo, string reference)
     {
+        reference = Uri.EscapeDataString(reference);
         Uri uri = new(string.Format(FetchRepo, repo, reference), UriKind.Absolute);
         LogFile.WriteLine("Downloading " + uri);
         return NetworkClient.GetStreamAsync(uri).GetAwaiter().GetResult();
@@ -27,12 +30,11 @@ public static class GitHub
 
     public static Stream GetRepoFile(string repo, string reference, string file)
     {
-        Uri uri = new(
-            string.Format(FetchFile, repo, reference) + file.TrimStart('/'),
-            UriKind.Absolute
-        );
+        reference = Uri.EscapeDataString(reference);
+        file = Uri.EscapeDataString(file.TrimStart('/')).Replace("%2F", "/");
+        Uri uri = new(string.Format(FetchFile, repo, file, reference), UriKind.Absolute);
         LogFile.WriteLine("Downloading " + uri);
-        return NetworkClient.GetStreamAsync(uri).GetAwaiter().GetResult();
+        return NetworkClient.GetStreamAsync(uri, RawContent).GetAwaiter().GetResult();
     }
 
     public static bool GetRepoHash(string repo, string reference, out string hash)

--- a/Shared/Network/GitHub.cs
+++ b/Shared/Network/GitHub.cs
@@ -6,6 +6,19 @@ namespace Pulsar.Shared.Network;
 
 public static class GitHub
 {
+    /// <summary>
+    /// Optional personal access token sent with requests to GitHub hosts to
+    /// lift the anonymous API rate limit (60 requests/hour per IP, which
+    /// shared or heavily automated machines exhaust quickly). Defaults to the
+    /// PULSAR_GITHUB_TOKEN environment variable; hosts embedding Pulsar can
+    /// set it directly. Never sent to non-GitHub hosts.
+    /// </summary>
+    public static string Token { get; set; } =
+        Environment.GetEnvironmentVariable("PULSAR_GITHUB_TOKEN");
+
+    internal static bool IsTokenHost(Uri uri) =>
+        uri.Host is "api.github.com" or "github.com" or "raw.githubusercontent.com";
+
     private const string CommitInfo = "https://api.github.com/repos/{0}/commits/{1}";
     private const string ReleaseInfo = "https://api.github.com/repos/{0}/releases";
     private const string FetchRepo = "https://github.com/{0}/archive/{1}.zip";

--- a/Shared/Network/GitHub.cs
+++ b/Shared/Network/GitHub.cs
@@ -6,13 +6,7 @@ namespace Pulsar.Shared.Network;
 
 public static class GitHub
 {
-    /// <summary>
-    /// Optional personal access token sent with requests to GitHub hosts to
-    /// lift the anonymous API rate limit (60 requests/hour per IP, which
-    /// shared or heavily automated machines exhaust quickly). Defaults to the
-    /// PULSAR_GITHUB_TOKEN environment variable; hosts embedding Pulsar can
-    /// set it directly. Never sent to non-GitHub hosts.
-    /// </summary>
+    // Optional GitHub PAT to lift the anonymous rate limit
     public static string Token { get; set; } =
         Environment.GetEnvironmentVariable("PULSAR_GITHUB_TOKEN");
 

--- a/Shared/Network/NetworkClient.cs
+++ b/Shared/Network/NetworkClient.cs
@@ -32,10 +32,14 @@ internal static class NetworkClient
         return await SendStringRequestAsync(request).ConfigureAwait(false);
     }
 
-    public static async Task<Stream> GetStreamAsync(Uri uri)
+    public static async Task<Stream> GetStreamAsync(Uri uri, string accept = null)
     {
         using CancellationTokenSource timeout = ResponseTimeout();
         using HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri);
+
+        if (accept is not null)
+            request.Headers.Accept.ParseAdd(accept);
+
         using HttpResponseMessage response = await Client
             .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token)
             .ConfigureAwait(false);

--- a/Shared/Network/NetworkClient.cs
+++ b/Shared/Network/NetworkClient.cs
@@ -89,9 +89,7 @@ internal static class NetworkClient
         HttpRequestMessage request = new(method, uri);
         request.Headers.UserAgent.ParseAdd(ConfigManager.Instance.Core.UserAgent);
 
-        // HttpClient drops the Authorization header on cross-host redirects
-        // (e.g. github.com -> codeload.github.com), so the token never leaks
-        // beyond the hosts checked here.
+        // Note HttpClient drops the Authorization header on redirects
         if (!string.IsNullOrWhiteSpace(GitHub.Token) && GitHub.IsTokenHost(uri))
             request.Headers.Authorization = new("Bearer", GitHub.Token);
 

--- a/Shared/Network/NetworkClient.cs
+++ b/Shared/Network/NetworkClient.cs
@@ -88,6 +88,13 @@ internal static class NetworkClient
     {
         HttpRequestMessage request = new(method, uri);
         request.Headers.UserAgent.ParseAdd(ConfigManager.Instance.Core.UserAgent);
+
+        // HttpClient drops the Authorization header on cross-host redirects
+        // (e.g. github.com -> codeload.github.com), so the token never leaks
+        // beyond the hosts checked here.
+        if (!string.IsNullOrWhiteSpace(GitHub.Token) && GitHub.IsTokenHost(uri))
+            request.Headers.Authorization = new("Bearer", GitHub.Token);
+
         return request;
     }
 

--- a/Shared/Tools.cs
+++ b/Shared/Tools.cs
@@ -12,7 +12,6 @@ using Newtonsoft.Json;
 using Pulsar.Compiler;
 using Pulsar.Interface;
 using Pulsar.Protocol.Interface;
-using Pulsar.Shared.Arguments;
 #if NETCOREAPP
 using System.Runtime.Versioning;
 #endif
@@ -174,29 +173,12 @@ public static class Tools
         });
     }
 
-    /// <param name="unattendedResult">
-    /// The result to report when the prompt cannot be shown (suppressed by
-    /// -noPrompt, or the interface process is unavailable). Defaults to Ok
-    /// for Ok-only prompts and Cancel otherwise. The message is logged so
-    /// unattended machines keep a trace of what was auto-answered.
-    /// </param>
     public static PromptResult ShowMessageBox(
         string message,
         PromptButtons buttons,
-        PromptIcon icon,
-        PromptResult? unattendedResult = null
+        PromptIcon icon
     )
     {
-        PromptResult fallback =
-            unattendedResult
-            ?? (buttons == PromptButtons.Ok ? PromptResult.Ok : PromptResult.Cancel);
-
-        if (Flags.Current?.NoPrompt ?? false)
-        {
-            LogPrompt(message, icon, fallback);
-            return fallback;
-        }
-
         try
         {
             return Interface.ShowPrompt(message, buttons, icon);
@@ -204,21 +186,8 @@ public static class Tools
         catch (Exception e)
         {
             LogFile.Error("Error while opening message box: " + e);
-            LogPrompt(message, icon, fallback);
-            return fallback;
+            return buttons == PromptButtons.Ok ? PromptResult.Ok : PromptResult.Cancel;
         }
-    }
-
-    private static void LogPrompt(string message, PromptIcon icon, PromptResult result)
-    {
-        string line = $"Prompt auto-answered '{result}': {message}";
-
-        if (icon == PromptIcon.Error)
-            LogFile.Error(line);
-        else if (icon == PromptIcon.Warning)
-            LogFile.Warn(line);
-        else
-            LogFile.WriteLine(line);
     }
 
     public static IEnumerable<string> GetFiles(

--- a/Shared/Tools.cs
+++ b/Shared/Tools.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using Pulsar.Compiler;
 using Pulsar.Interface;
 using Pulsar.Protocol.Interface;
+using Pulsar.Shared.Arguments;
 #if NETCOREAPP
 using System.Runtime.Versioning;
 #endif
@@ -173,12 +174,29 @@ public static class Tools
         });
     }
 
+    /// <param name="unattendedResult">
+    /// The result to report when the prompt cannot be shown (suppressed by
+    /// -noPrompt, or the interface process is unavailable). Defaults to Ok
+    /// for Ok-only prompts and Cancel otherwise. The message is logged so
+    /// unattended machines keep a trace of what was auto-answered.
+    /// </param>
     public static PromptResult ShowMessageBox(
         string message,
         PromptButtons buttons,
-        PromptIcon icon
+        PromptIcon icon,
+        PromptResult? unattendedResult = null
     )
     {
+        PromptResult fallback =
+            unattendedResult
+            ?? (buttons == PromptButtons.Ok ? PromptResult.Ok : PromptResult.Cancel);
+
+        if (Flags.Current?.NoPrompt ?? false)
+        {
+            LogPrompt(message, icon, fallback);
+            return fallback;
+        }
+
         try
         {
             return Interface.ShowPrompt(message, buttons, icon);
@@ -186,8 +204,21 @@ public static class Tools
         catch (Exception e)
         {
             LogFile.Error("Error while opening message box: " + e);
-            return buttons == PromptButtons.Ok ? PromptResult.Ok : PromptResult.Cancel;
+            LogPrompt(message, icon, fallback);
+            return fallback;
         }
+    }
+
+    private static void LogPrompt(string message, PromptIcon icon, PromptResult result)
+    {
+        string line = $"Prompt auto-answered '{result}': {message}";
+
+        if (icon == PromptIcon.Error)
+            LogFile.Error(line);
+        else if (icon == PromptIcon.Warning)
+            LogFile.Warn(line);
+        else
+            LogFile.WriteLine(line);
     }
 
     public static IEnumerable<string> GetFiles(

--- a/Shared/Updater.cs
+++ b/Shared/Updater.cs
@@ -49,8 +49,6 @@ public class Updater(string repoName)
         PromptResult result = ShowUpdatePrompt(localPulsarVer, remotePulsarVer);
         if (result == PromptResult.Yes)
             Update();
-        else if (result == PromptResult.Cancel)
-            Environment.Exit(0);
     }
 
     private static bool IsWritable(string directory)
@@ -75,14 +73,7 @@ public class Updater(string repoName)
             + $"{localVer.ToString(3)} -> {remoteVer.ToString(3)}\n"
             + "Would you like to update now?";
 
-        // Unattended machines skip the update and keep launching; the Cancel
-        // fallback would exit the process instead.
-        return Tools.ShowMessageBox(
-            prompt,
-            PromptButtons.YesNoCancel,
-            PromptIcon.Question,
-            PromptResult.No
-        );
+        return Tools.ShowMessageBox(prompt, PromptButtons.YesNo, PromptIcon.Question);
     }
 
     public static void GameUpdatePrompt(Version oldVersion, Version newVersion, int fieldCount)
@@ -102,17 +93,9 @@ public class Updater(string repoName)
             + "Snapshots of the Plugin Hub are available if you choose to revert.\n"
             + "Do you wish to continue?";
 
-        // Unattended machines must continue: any other fallback would exit
-        // on every launch after a game update, boot-looping hosts that
-        // restart the process automatically.
-        PromptResult result = Tools.ShowMessageBox(
-            prompt,
-            PromptButtons.YesNo,
-            PromptIcon.Warning,
-            PromptResult.Yes
-        );
+        PromptResult result = Tools.ShowMessageBox(prompt, PromptButtons.YesNo, PromptIcon.Warning);
 
-        if (result != PromptResult.Yes)
+        if (result == PromptResult.No)
             Environment.Exit(0);
 
         GitHubPlugin.ClearGitHubCache();

--- a/Shared/Updater.cs
+++ b/Shared/Updater.cs
@@ -75,7 +75,14 @@ public class Updater(string repoName)
             + $"{localVer.ToString(3)} -> {remoteVer.ToString(3)}\n"
             + "Would you like to update now?";
 
-        return Tools.ShowMessageBox(prompt, PromptButtons.YesNoCancel, PromptIcon.Question);
+        // Unattended machines skip the update and keep launching; the Cancel
+        // fallback would exit the process instead.
+        return Tools.ShowMessageBox(
+            prompt,
+            PromptButtons.YesNoCancel,
+            PromptIcon.Question,
+            PromptResult.No
+        );
     }
 
     public static void GameUpdatePrompt(Version oldVersion, Version newVersion, int fieldCount)
@@ -95,7 +102,15 @@ public class Updater(string repoName)
             + "Snapshots of the Plugin Hub are available if you choose to revert.\n"
             + "Do you wish to continue?";
 
-        PromptResult result = Tools.ShowMessageBox(prompt, PromptButtons.YesNo, PromptIcon.Warning);
+        // Unattended machines must continue: any other fallback would exit
+        // on every launch after a game update, boot-looping hosts that
+        // restart the process automatically.
+        PromptResult result = Tools.ShowMessageBox(
+            prompt,
+            PromptButtons.YesNo,
+            PromptIcon.Warning,
+            PromptResult.Yes
+        );
 
         if (result != PromptResult.Yes)
             Environment.Exit(0);


### PR DESCRIPTION
Four independent fixes/features motivated by embedding Pulsar in the dedicated-server host (Magnetar), one commit each so they can be cherry-picked into separate PRs:

**Bug fixes**

- **Argument parser**: `Parser.Normalize` no longer rewrites option *values* into flags. Only tokens starting with `-` or `/` are normalized, so a value such as `-profile bare` no longer turns into the `-bare` flag.
- **Unattended prompts**: with `-noPrompt` every dialog used to be silently answered `Cancel` (the enum default), which discarded fatal messages and made both update prompts exit the process, boot-looping auto-restarted hosts after every game update. `Tools.ShowMessageBox` now logs the prompt text and auto-answers with a per-call `unattendedResult`: the Pulsar update prompt answers No (skip update, keep launching) and the game update prompt answers Yes (log, clear plugin caches, continue). All other call sites keep their previous, safe defaults.

**Feature**

- **GitHub token support**: new public `GitHub.Token` property (defaults to the `PULSAR_GITHUB_TOKEN` environment variable). `NetworkClient` sends it as a `Bearer` header only to `api.github.com`, `github.com` and `raw.githubusercontent.com`, lifting the anonymous 60 requests/hour API limit. Without a token nothing changes.