### PR TITLE
Fix Linux file/folder pickers (Avalonia 11.3.20)

### DIFF
--- a/Interface/Interface.csproj
+++ b/Interface/Interface.csproj
@@ -57,6 +57,7 @@
       <DeployFile Include="$(TargetDir)Avalonia.Skia.dll" />
       <DeployFile Include="$(TargetDir)Avalonia.Themes.Fluent.dll" />
       <DeployFile Include="$(TargetDir)Avalonia.Metal.dll" />
+      <DeployFile Include="$(TargetDir)Avalonia.Vulkan.dll" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
       <DeployFile Include="$(TargetDir)$(AssemblyName).exe.config" />
@@ -64,10 +65,11 @@
       <DeployFile Include="$(TargetDir)x64/libSkiaSharp.dll" />
       <DeployFile Include="$(TargetDir)av_libglesv2.dll" />
       <DeployFile Include="$(TargetDir)Avalonia.Win32.dll" />
+      <DeployFile Include="$(TargetDir)Avalonia.Win32.Automation.dll" />
       <DeployFile Include="$(TargetDir)Microsoft.Bcl.AsyncInterfaces.dll" />
       <DeployFile Include="$(TargetDir)System.Buffers.dll" />
       <DeployFile Include="$(TargetDir)System.Memory.dll" />
-      <DeployFile Include="$(TargetDir)System.ValueTuple.dll" />
+      <DeployFile Include="$(TargetDir)System.Diagnostics.DiagnosticSource.dll" />
       <DeployFile Include="$(TargetDir)System.ComponentModel.Annotations.dll" />
       <DeployFile Include="$(TargetDir)System.Numerics.Vectors.dll" />
       <DeployFile Include="$(TargetDir)System.Runtime.CompilerServices.Unsafe.dll" />
@@ -99,8 +101,8 @@
     <ProjectReference Include="../Protocol/Protocol.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.10" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.20" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.20" />
     <PackageReference Include="AnimatedImage.Avalonia" Version="2.1.4" />
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
   </ItemGroup>

--- a/Interface/WindowManager.cs
+++ b/Interface/WindowManager.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
 using Pulsar.Protocol.Interface;
 
@@ -127,7 +128,7 @@ internal sealed class WindowManager(IClassicDesktopStyleApplicationLifetime desk
     public async Task<string> GetClipboard()
     {
         using FallbackOwner owner = new(dialog: false);
-        return await owner.Clipboard.GetTextAsync() ?? string.Empty;
+        return await owner.Clipboard.TryGetTextAsync() ?? string.Empty;
     }
 
     public void Shutdown()

--- a/Modern/Program.cs
+++ b/Modern/Program.cs
@@ -303,7 +303,7 @@ static class Program
 
         Game.RegisterPlugin(typeof(PluginLoader));
 
-        SplashManager.Instance?.SetText("Launching Space Engineers...");
+        SplashManager.Instance?.SetText("Launching Space Engineers 2...");
         SplashManager.Instance?.SetBarValue(0);
         Game.StartSpaceEngineers2(args);
     }


### PR DESCRIPTION
## Summary

On Linux, opening any file or folder picker (e.g. adding a dev folder in the Sources dialog) failed with:

```
TypeLoadException: Could not load type 'Tmds.DBus.Protocol.Utf8Span' from assembly 'Tmds.DBus.Protocol, Version=0.21.3.0'
```

Avalonia 11.0.10's FreeDesktop backend was compiled against Tmds.DBus.Protocol 0.15 and references `Utf8Span`, which was removed in 0.21.0. The 0.21.3 pin (needed for GHSA-xrw6-gwf8-vvr9) therefore broke every XDG portal dialog.

## Changes

- Upgrade Avalonia to 11.3.20, which is built against Tmds.DBus.Protocol 0.21.3. The security pin stays.
- Update the Interface deploy lists for 11.3: `Avalonia.Vulkan` on both platforms; `Avalonia.Win32.Automation` and `System.Diagnostics.DiagnosticSource` on Windows, where `System.ValueTuple` is no longer shipped.
- Replace the now-obsolete `IClipboard.GetTextAsync` with `TryGetTextAsync`.
- Splash text for SE2 now says "Launching Space Engineers 2...".

## Testing

- Linux (net10.0) and Windows (net48) targets build with zero warnings; the Windows deploy list was validated by deploying into a scratch folder.
- Drove the deployed Linux Interface over IPC: Hello then FolderOpen. The portal folder dialog opened and returned the selected path.