### PR TITLE
fix: exclude launcher UI from Steam overlay

### DIFF
--- a/Shared/Interface/InterfaceClient.cs
+++ b/Shared/Interface/InterfaceClient.cs
@@ -142,6 +142,8 @@ public sealed class InterfaceClient(string interfacePath) : IDisposable
             CreateNoWindow = true,
         };
 
+        SteamOverlay.DisableForHelper(startInfo);
+
         try
         {
             process = new Process { StartInfo = startInfo };

--- a/Shared/SteamOverlay.cs
+++ b/Shared/SteamOverlay.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Pulsar.Shared;
+
+internal static class SteamOverlay
+{
+    private const string EnableVulkan = "ENABLE_VK_LAYER_VALVE_steam_overlay_1";
+    private const string DisableVulkan = "DISABLE_VK_LAYER_VALVE_steam_overlay_1";
+
+    public static void DisableForHelper(ProcessStartInfo startInfo)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return;
+
+        // The Avalonia splash/dialog process must not create a second game overlay.
+        // Only change the child's environment; retain other preloaded libraries.
+        if (startInfo.Environment.TryGetValue("LD_PRELOAD", out string preload))
+        {
+            string[] libraries = (preload ?? "").Split(
+                [':', ' '],
+                StringSplitOptions.RemoveEmptyEntries
+            );
+            string filtered = string.Join(
+                ":",
+                libraries.Where(path => Path.GetFileName(path) != "gameoverlayrenderer.so")
+            );
+            if (filtered.Length == 0)
+                startInfo.Environment.Remove("LD_PRELOAD");
+            else
+                startInfo.Environment["LD_PRELOAD"] = filtered;
+        }
+
+        startInfo.Environment.Remove(EnableVulkan);
+        startInfo.Environment[DisableVulkan] = "1";
+    }
+}

--- a/Tests/SteamOverlay/Program.cs
+++ b/Tests/SteamOverlay/Program.cs
@@ -1,0 +1,69 @@
+// Run on Linux: dotnet run --project Tests/SteamOverlay
+using System;
+using System.Diagnostics;
+using Pulsar.Shared;
+
+if (!OperatingSystem.IsLinux())
+    throw new PlatformNotSupportedException("Run this regression check on Linux.");
+
+const string enable = "ENABLE_VK_LAYER_VALVE_steam_overlay_1";
+const string disable = "DISABLE_VK_LAYER_VALVE_steam_overlay_1";
+
+void Check(bool condition, string message)
+{
+    if (!condition)
+        throw new Exception(message);
+}
+
+Environment.SetEnvironmentVariable(enable, "1");
+Environment.SetEnvironmentVariable(disable, null);
+Environment.SetEnvironmentVariable("SDL_VIDEO_DRIVER", "wayland");
+
+const string preload =
+    ":/steam/ubuntu12_32/gameoverlayrenderer.so:/steam/ubuntu12_64/gameoverlayrenderer.so libkeep.so";
+Environment.SetEnvironmentVariable("LD_PRELOAD", preload);
+Environment.SetEnvironmentVariable("SteamGameId", "244850");
+using (Process child = new())
+{
+    child.StartInfo = new ProcessStartInfo("/usr/bin/env")
+    {
+        UseShellExecute = false,
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        WorkingDirectory = "/tmp",
+    };
+    SteamOverlay.DisableForHelper(child.StartInfo);
+    Check(child.StartInfo.Environment["LD_PRELOAD"] == "libkeep.so", "Preserve unrelated preloads");
+    Check(child.StartInfo.Environment["SteamGameId"] == "244850", "Preserve game identity");
+    Check(
+        child.StartInfo.Environment["SDL_VIDEO_DRIVER"] == "wayland",
+        "Preserve Wayland selection"
+    );
+    Check(child.StartInfo.WorkingDirectory == "/tmp", "Preserve helper launch path");
+    Check(Environment.GetEnvironmentVariable("LD_PRELOAD") == preload, "Keep parent injection");
+    Check(Environment.GetEnvironmentVariable(enable) == "1", "Keep parent Vulkan overlay");
+    Check(Environment.GetEnvironmentVariable(disable) == null, "Do not disable parent overlay");
+    // The unrelated fake library need not exist to check the child's actual environment.
+    child.Start();
+    string output = child.StandardOutput.ReadToEnd();
+    child.StandardError.ReadToEnd();
+    child.WaitForExit();
+    Check(child.ExitCode == 0, "Helper starts successfully");
+    Check(output.Contains("LD_PRELOAD=libkeep.so\n"), "Child retains unrelated preload");
+    Check(output.Contains(disable + "=1\n"), "Child disables Vulkan overlay");
+    Check(!output.Contains(enable + "="), "Child has no Vulkan overlay opt-in");
+    Check(!output.Contains("gameoverlayrenderer.so"), "Child has no overlay injection");
+}
+
+foreach (string value in new[] { "gameoverlayrenderer.so", "", null })
+{
+    ProcessStartInfo startInfo = new();
+    if (value == null)
+        startInfo.Environment.Remove("LD_PRELOAD");
+    else
+        startInfo.Environment["LD_PRELOAD"] = value;
+    SteamOverlay.DisableForHelper(startInfo);
+    Check(!startInfo.Environment.ContainsKey("LD_PRELOAD"), "Handle empty or overlay-only preload");
+}
+
+Console.WriteLine("Steam overlay regression checks passed.");

--- a/Tests/SteamOverlay/SteamOverlay.csproj
+++ b/Tests/SteamOverlay/SteamOverlay.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../Shared/SteamOverlay.cs" Link="SteamOverlay.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
On Linux, Steam injects its overlay into Pulsar’s Avalonia splash/dialog process as well as the game. Launch the helper with Steam’s `gameoverlayrenderer.so` entries removed from `LD_PRELOAD` and the Steam Vulkan overlay layer disabled in the child environment.

Preserves unrelated preloads, the parent game’s overlay environment, Steam identity, launch arguments, and video-driver selection. Applies only to Linux helper launches. A standalone regression check verifies the environment passed to a real child process.

Validation:
- `dotnet run --project Tests/SteamOverlay` passed.
- Shared Release builds passed for net10.0 and net48 with no warnings or errors.
- In a local installed build, the game retained Steam’s overlay while the Avalonia helper did not map `gameoverlayrenderer.so`.

This is separate from the native Wayland input bridge in https://github.com/CometWorks/linux-compat/pull/40: skipping the splash and prompts alone did not restore Shift+Tab. LinuxCompat distributes that fix through PluginHub; this helper-isolation change ships with the next Pulsar release.
